### PR TITLE
updated aws config to use .env regions

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -18,7 +18,7 @@ module.exports = {
     aws: {
         admin_access_key: process.env.AWS_ADMIN_ACCESS_KEY,
         admin_secret_access_key: process.env.AWS_ADMIN_SECRET_ACCESS_KEY,
-        aws_region: 'us-east-1'
+        aws_region: process.env.AWS_LAMBDA_REGIONS.split(',')[0]
     },
 
     // JSON Web Token


### PR DESCRIPTION
Is there a specific reason you hard coded 'us-east-1'?

I'm currently working out of 'us-west-2' and it obviously causes errors when trying to run lambda's locally.